### PR TITLE
Modify "Revoke" menu item keyboard shortcuts

### DIFF
--- a/WeChatExtension/WeChatExtension/Sources/Managers/TKAssistantMenuManager.m
+++ b/WeChatExtension/WeChatExtension/Sources/Managers/TKAssistantMenuManager.m
@@ -39,7 +39,7 @@ static char kAboutWindowControllerKey;             //  关于窗口的关联 key
     NSMenuItem *preventRevokeItem = [NSMenuItem menuItemWithTitle:YMLanguage(@"开启消息防撤回", @"Revoke")
                                                            action:@selector(onPreventRevoke:)
                                                            target:self
-                                                    keyEquivalent:@"t"
+                                                    keyEquivalent:@"T"
                                                             state:[[TKWeChatPluginConfig sharedConfig] preventRevokeEnable]];
     if ([[TKWeChatPluginConfig sharedConfig] preventRevokeEnable]) {
         //        防撤回自己


### PR DESCRIPTION
由于"CMD + T"快捷键使用频率较高, 经常被误触,
所以更改菜单栏中"开启消息防撤回"的快捷键为"CMD + Shift + t"

fix #323