### PR TITLE
使用 GVUserDefaults 避免冗余的 setter 代码

### DIFF
--- a/WeChatExtension/WeChatExtension.xcodeproj/project.pbxproj
+++ b/WeChatExtension/WeChatExtension.xcodeproj/project.pbxproj
@@ -154,6 +154,8 @@
 		36AC9D8B228A81C200EA9F97 /* XMLReader.m in Sources */ = {isa = PBXBuildFile; fileRef = 36AC9D89228A81C200EA9F97 /* XMLReader.m */; };
 		8EB413EE2E0AB9424DB91B42 /* libPods-WeChatExtensionTests.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 8B176B73969A171B6926048F /* libPods-WeChatExtensionTests.a */; };
 		96B578BF2360AA8A00F3F66C /* Localizable.strings in Resources */ = {isa = PBXBuildFile; fileRef = 96B578C12360AA8A00F3F66C /* Localizable.strings */; };
+		D79D23592449EF5D00C391E4 /* GVUserDefaults.h in Headers */ = {isa = PBXBuildFile; fileRef = D79D23572449EF5C00C391E4 /* GVUserDefaults.h */; };
+		D79D235A2449EF5D00C391E4 /* GVUserDefaults.m in Sources */ = {isa = PBXBuildFile; fileRef = D79D23582449EF5C00C391E4 /* GVUserDefaults.m */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -330,6 +332,8 @@
 		96D8D0952360BC6A0025BAD6 /* en */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = en; path = en.lproj/TKRemoteControlWindowController.strings; sourceTree = "<group>"; };
 		96D8D0972360BC6C0025BAD6 /* zh-Hans */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = "zh-Hans"; path = "zh-Hans.lproj/TKRemoteControlWindowController.strings"; sourceTree = "<group>"; };
 		96D8D0992360BC6E0025BAD6 /* zh-Hant */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = "zh-Hant"; path = "zh-Hant.lproj/TKRemoteControlWindowController.strings"; sourceTree = "<group>"; };
+		D79D23572449EF5C00C391E4 /* GVUserDefaults.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = GVUserDefaults.h; sourceTree = "<group>"; };
+		D79D23582449EF5C00C391E4 /* GVUserDefaults.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = GVUserDefaults.m; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -514,6 +518,8 @@
 		188A65B62272ACBA0096663E /* Utils */ = {
 			isa = PBXGroup;
 			children = (
+				D79D23572449EF5C00C391E4 /* GVUserDefaults.h */,
+				D79D23582449EF5C00C391E4 /* GVUserDefaults.m */,
 				188A65B72272ACBA0096663E /* YMHelper.h */,
 				188A65B92272ACBA0096663E /* YMHelper.m */,
 				188A65BA2272ACBA0096663E /* YMUtility.h */,
@@ -753,6 +759,7 @@
 				188A662B2272ACBA0096663E /* NSString+Action.h in Headers */,
 				188A660B2272ACBA0096663E /* TKRemoteControlManager.h in Headers */,
 				36AC9D8A228A81C200EA9F97 /* XMLReader.h in Headers */,
+				D79D23592449EF5D00C391E4 /* GVUserDefaults.h in Headers */,
 				18D4C34B24236180006A20E2 /* NSObject+ThemeHook.h in Headers */,
 				3632294222AFD9CF00F62EAB /* YMThemeMgr.h in Headers */,
 				18A7A16A2272AFE600361A98 /* GCDWebServerMultiPartFormRequest.h in Headers */,
@@ -1018,6 +1025,7 @@
 				18D298F3239610F8009EE6B0 /* YMAIReplyCell.m in Sources */,
 				18A7A15A2272AFE600361A98 /* GCDWebServerRequest.m in Sources */,
 				18A7A16D2272AFE600361A98 /* GCDWebServerMultiPartFormRequest.m in Sources */,
+				D79D235A2449EF5D00C391E4 /* GVUserDefaults.m in Sources */,
 				188A66312272ACBA0096663E /* TKAutoReplyContentView.m in Sources */,
 				188A66242272ACBA0096663E /* NSDate+Action.m in Sources */,
 				18D298532394EE60009EE6B0 /* YMNetWorkHelper.m in Sources */,

--- a/WeChatExtension/WeChatExtension/Sources/Config/TKWeChatPluginConfig.h
+++ b/WeChatExtension/WeChatExtension/Sources/Config/TKWeChatPluginConfig.h
@@ -8,6 +8,7 @@
 
 
 #import <Foundation/Foundation.h>
+#import "GVUserDefaults.h"
 
 typedef NS_ENUM(NSInteger, PluginLanguageType) {
     PluginLanguageTypeZH,
@@ -15,41 +16,42 @@ typedef NS_ENUM(NSInteger, PluginLanguageType) {
 };
 
 @class YMAIAutoModel;
-@interface TKWeChatPluginConfig : NSObject
 
-@property (nonatomic, assign) BOOL preventRevokeEnable;                 /**<    是否开启防撤回    */
-@property (nonatomic, assign) BOOL preventSelfRevokeEnable;             /**<    是否防撤回自己    */
-@property (nonatomic, assign)  BOOL preventAsyncRevokeToPhone;           /**<    是否将防撤回同步到手机    */
-@property (nonatomic, assign) BOOL preventAsyncRevokeSignal;             /**<    只同步单聊    */
-@property (nonatomic, assign) BOOL preventAsyncRevokeChatRoom;           /**<    只同步群聊    */
-@property (nonatomic, assign) BOOL autoReplyEnable;                     /**<    是否开启自动回复  */
-@property (nonatomic, assign) BOOL autoAuthEnable;                      /**<    是否免认证登录    */
-@property (nonatomic, assign) BOOL launchFromNew;                       /**<    是否是从 -> 登录新微信 -> 启动      */
-@property (nonatomic, assign) BOOL quitMonitorEnable;
-@property (nonatomic, assign) BOOL autoLoginEnable;                     /**<    是否自动登录      */
-@property (nonatomic, assign) BOOL onTop;                               /**<    是否要置顶微信    */
-@property (nonatomic, assign) BOOL multipleSelectionEnable;             /**<    是否要进行多选    */
-@property (nonatomic, assign) BOOL forbidCheckVersion;                  /**<    禁止检测版本      */
-@property (nonatomic, assign) BOOL alfredEnable;                        /**<    是否开启Alfred   */
-@property (nonatomic, assign) BOOL checkUpdateWechatEnable;             /**<    是否允许微信启动检测更新  */
-@property (nonatomic, assign) BOOL systemBrowserEnable;                 /**<    是否使用自身浏览器打开连接   */
+@interface TKWeChatPluginConfig : GVUserDefaults
+
+@property (nonatomic) BOOL preventRevokeEnable;                 /**<    是否开启防撤回    */
+@property (nonatomic) BOOL preventSelfRevokeEnable;             /**<    是否防撤回自己    */
+@property (nonatomic) BOOL preventAsyncRevokeToPhone;           /**<    是否将防撤回同步到手机    */
+@property (nonatomic) BOOL preventAsyncRevokeSignal;            /**<    只同步单聊    */
+@property (nonatomic) BOOL preventAsyncRevokeChatRoom;          /**<    只同步群聊    */
+@property (nonatomic) BOOL autoReplyEnable;                     /**<    是否开启自动回复  */
+@property (nonatomic) BOOL autoAuthEnable;                      /**<    是否免认证登录    */
+@property (nonatomic) BOOL launchFromNew;                       /**<    是否是从 -> 登录新微信 -> 启动      */
+@property (nonatomic) BOOL quitMonitorEnable;
+@property (nonatomic) BOOL autoLoginEnable;                     /**<    是否自动登录      */
+@property (nonatomic) BOOL onTop;                               /**<    是否要置顶微信    */
+@property (nonatomic) BOOL multipleSelectionEnable;             /**<    是否要进行多选    */
+@property (nonatomic) BOOL forbidCheckVersion;                  /**<    禁止检测版本      */
+@property (nonatomic) BOOL alfredEnable;                        /**<    是否开启Alfred   */
+@property (nonatomic) BOOL checkUpdateWechatEnable;             /**<    是否允许微信启动检测更新  */
+@property (nonatomic) BOOL systemBrowserEnable;                 /**<    是否使用自身浏览器打开连接   */
+@property (nonatomic, copy) NSString *currentUserName;          /**<    当前用户的id     */
+@property (nonatomic) BOOL isAllowMoreOpenBaby;
+@property (nonatomic) BOOL darkMode;
+@property (nonatomic) BOOL pinkMode;
+@property (nonatomic) BOOL groupMultiColorMode;
+@property (nonatomic) BOOL isThemeLoaded;
+
 @property (nonatomic, strong) NSMutableArray *autoReplyModels;           /**<    自动回复的数组    */
 @property (nonatomic, strong) NSMutableArray *remoteControlModels;       /**<    远程控制的数组    */
 @property (nonatomic, strong) NSMutableArray *ignoreSessionModels;       /**<    聊天置底的数组    */
 @property (nonatomic, strong) NSMutableArray *selectSessions;            /**<    已经选中的会话    */
 @property (nonatomic, strong) NSMutableSet *revokeMsgSet;                /**<    撤回的消息集合    */
 @property (nonatomic, strong) NSMutableSet *unreadSessionSet;            /**<    标记未读消息集合    */
-@property (nonatomic, copy) NSString *currentUserName;                   /**<    当前用户的id     */
 @property (nonatomic, copy, readonly) NSDictionary *localInfoPlist;
 @property (nonatomic, copy, readonly) NSDictionary *romoteInfoPlist;
 @property (nonatomic, strong) YMAIAutoModel *AIReplyModel;
-@property (nonatomic, assign) PluginLanguageType languageType;
-@property (nonatomic, assign) BOOL isAllowMoreOpenBaby;
-
-@property (nonatomic, assign) BOOL darkMode;
-@property (nonatomic, assign) BOOL pinkMode;
-@property (nonatomic, assign) BOOL groupMultiColorMode;
-@property (nonatomic, assign) BOOL isThemeLoaded;
+@property (nonatomic) PluginLanguageType languageType;
 
 - (void)saveAutoReplyModels;
 - (void)saveRemoteControlModels;
@@ -61,5 +63,6 @@ typedef NS_ENUM(NSInteger, PluginLanguageType) {
 - (void)saveMonitorQuitMembers:(NSMutableArray *)members;
 - (NSMutableArray *)getMonitorQuitMembers;
 - (NSString *)languageSetting:(NSString *)chinese english:(NSString *)english;
+
 @end
 

--- a/WeChatExtension/WeChatExtension/Sources/Config/TKWeChatPluginConfig.m
+++ b/WeChatExtension/WeChatExtension/Sources/Config/TKWeChatPluginConfig.m
@@ -12,29 +12,9 @@
 #import "TKIgnoreSessonModel.h"
 #import "WeChatPlugin.h"
 #import "YMIMContactsManager.h"
-static NSString * const kTKPreventRevokeEnableKey = @"kTKPreventRevokeEnableKey";
-static NSString * const kTKPreventSelfRevokeEnableKey = @"kTKPreventSelfRevokeEnableKey";
-static NSString * const kTKPreventAsyncRevokeKey = @"kTKPreventAsyncRevokeKey";
-static NSString * const KPreventAsyncRevokeSignal = @"KPreventAsyncRevokeSignal";
-static NSString * const KPreventAsyncRevokeChatRoom = @"KPreventAsyncRevokeChatRoom";
-static NSString * const KQuitMonitorChatRoom = @"KQuitMonitorChatRoom";
-static NSString * const kTKAutoReplyEnableKey = @"kTKAutoReplyEnableKey";
-static NSString * const kTKAutoAuthEnableKey = @"kTKAutoAuthEnableKey";
-static NSString * const kTKLaunchFromNew = @"kTKLaunchFromNew";
-static NSString * const kTKAutoLoginEnableKey = @"kTKAutoLoginEnableKey";
-static NSString * const kTKOnTopKey = @"kTKOnTopKey";
-static NSString * const kTKForbidCheckVersionKey = @"kTKForbidCheckVersionKey";
-static NSString * const kTKAlfredEnableKey = @"kTKAlfredEnableKey";
-static NSString * const kTKCheckUpdateWechatEnableKey = @"kTKCheckUpdateWechatEnableKey";
-static NSString * const kTKSystemBrowserEnableKey = @"kTKSystemBrowserEnableKey";
+
 static NSString * const kTKWeChatResourcesPath = @"/Applications/WeChat.app/Contents/MacOS/WeChatExtension.framework/Resources/";
 static NSString * const kTKWeChatRemotePlistPath = @"https://raw.githubusercontent.com/MustangYM/WeChatExtension-ForMac/master/WeChatExtension/WeChatExtension/Base.lproj/Info.plist";
-static NSString * const kisAllowMoreOpenBaby = @"kisAllowMoreOpenBaby";
-
-static NSString * const kDarkMode = @"kDarkMode";
-static NSString * const kPinkMode = @"kPinkMode";
-static NSString * const kGroupMultiColorMode = @"kGroupMultiColorMode";
-static NSString * const kFirstLoadMode = @"kThemeLoadMode.";
 
 @interface TKWeChatPluginConfig ()
 
@@ -49,167 +29,36 @@ static NSString * const kFirstLoadMode = @"kThemeLoadMode.";
 
 @implementation TKWeChatPluginConfig
 
+@dynamic preventRevokeEnable;
+@dynamic preventSelfRevokeEnable;
+@dynamic preventAsyncRevokeToPhone;
+@dynamic preventAsyncRevokeSignal;
+@dynamic preventAsyncRevokeChatRoom;
+@dynamic autoReplyEnable;
+@dynamic autoAuthEnable;
+@dynamic launchFromNew;
+@dynamic quitMonitorEnable;
+@dynamic autoLoginEnable;
+@dynamic onTop;
+@dynamic multipleSelectionEnable;
+@dynamic forbidCheckVersion;
+@dynamic alfredEnable;
+@dynamic checkUpdateWechatEnable;
+@dynamic systemBrowserEnable;
+@dynamic currentUserName;
+@dynamic isAllowMoreOpenBaby;
+@dynamic darkMode;
+@dynamic pinkMode;
+@dynamic groupMultiColorMode;
+@dynamic isThemeLoaded;
+
 + (instancetype)sharedConfig {
     static TKWeChatPluginConfig *config = nil;
     static dispatch_once_t onceToken;
     dispatch_once(&onceToken, ^{
-        config = [[TKWeChatPluginConfig alloc] init];
+        config = [TKWeChatPluginConfig standardUserDefaults];
     });
     return config;
-}
-
-- (instancetype)init {
-    self = [super init];
-    if (self) {
-        _preventRevokeEnable = [[NSUserDefaults standardUserDefaults] boolForKey:kTKPreventRevokeEnableKey];
-        _preventSelfRevokeEnable = [[NSUserDefaults standardUserDefaults] boolForKey:kTKPreventSelfRevokeEnableKey];
-        _autoReplyEnable = [[NSUserDefaults standardUserDefaults] boolForKey:kTKAutoReplyEnableKey];
-        _autoAuthEnable = [[NSUserDefaults standardUserDefaults] boolForKey:kTKAutoAuthEnableKey];
-        _launchFromNew = [[NSUserDefaults standardUserDefaults] boolForKey:kTKLaunchFromNew];
-        _autoLoginEnable = [[NSUserDefaults standardUserDefaults] boolForKey:kTKAutoLoginEnableKey];
-        _onTop = [[NSUserDefaults standardUserDefaults] boolForKey:kTKOnTopKey];
-        _forbidCheckVersion = [[NSUserDefaults standardUserDefaults] boolForKey:kTKForbidCheckVersionKey];
-        _alfredEnable = [[NSUserDefaults standardUserDefaults] boolForKey:kTKAlfredEnableKey];
-        _checkUpdateWechatEnable = [[NSUserDefaults standardUserDefaults] boolForKey:kTKCheckUpdateWechatEnableKey];
-        _systemBrowserEnable = [[NSUserDefaults standardUserDefaults] boolForKey:kTKSystemBrowserEnableKey];
-        _preventAsyncRevokeToPhone = [[NSUserDefaults standardUserDefaults] boolForKey:kTKPreventAsyncRevokeKey];
-        _preventAsyncRevokeSignal = [[NSUserDefaults standardUserDefaults] boolForKey:KPreventAsyncRevokeSignal];
-        _preventAsyncRevokeChatRoom = [[NSUserDefaults standardUserDefaults] boolForKey:KPreventAsyncRevokeChatRoom];
-        _quitMonitorEnable = [[NSUserDefaults standardUserDefaults] boolForKey:KQuitMonitorChatRoom];
-        _isAllowMoreOpenBaby = [[NSUserDefaults standardUserDefaults] boolForKey:kisAllowMoreOpenBaby];
-        _darkMode = [[NSUserDefaults standardUserDefaults] boolForKey:kDarkMode];
-        _pinkMode = [[NSUserDefaults standardUserDefaults] boolForKey:kPinkMode];
-        _groupMultiColorMode = [[NSUserDefaults standardUserDefaults] boolForKey:kGroupMultiColorMode];
-        _isThemeLoaded = [[NSUserDefaults standardUserDefaults] boolForKey:kFirstLoadMode];
-    }
-    return self;
-}
-
-- (void)setPinkMode:(BOOL)pinkMode
-{
-    _pinkMode = pinkMode;
-    [[NSUserDefaults standardUserDefaults] setBool:pinkMode forKey:kPinkMode];
-    [[NSUserDefaults standardUserDefaults] synchronize];
-}
-
-- (void)setGroupMultiColorMode:(BOOL)groupMultiColorMode
-{
-    _groupMultiColorMode = groupMultiColorMode;
-    [[NSUserDefaults standardUserDefaults] setBool:groupMultiColorMode forKey:kGroupMultiColorMode];
-    [[NSUserDefaults standardUserDefaults] synchronize];
-}
-
-- (void)setIsThemeLoaded:(BOOL)isThemeLoaded
-{
-    _isThemeLoaded = isThemeLoaded;
-    [[NSUserDefaults standardUserDefaults] setBool:isThemeLoaded forKey:kFirstLoadMode];
-    [[NSUserDefaults standardUserDefaults] synchronize];
-}
-
-- (void)setDarkMode:(BOOL)darkMode
-{
-    _darkMode = darkMode;
-    [[NSUserDefaults standardUserDefaults] setBool:darkMode forKey:kDarkMode];
-    [[NSUserDefaults standardUserDefaults] synchronize];
-}
-
-- (void)setIsAllowMoreOpenBaby:(BOOL)isAllowMoreOpenBaby
-{
-    _isAllowMoreOpenBaby = isAllowMoreOpenBaby;
-    [[NSUserDefaults standardUserDefaults] setBool:isAllowMoreOpenBaby forKey:kisAllowMoreOpenBaby];
-    [[NSUserDefaults standardUserDefaults] synchronize];
-}
-
-- (void)setPreventRevokeEnable:(BOOL)preventRevokeEnable {
-    _preventRevokeEnable = preventRevokeEnable;
-    [[NSUserDefaults standardUserDefaults] setBool:preventRevokeEnable forKey:kTKPreventRevokeEnableKey];
-    [[NSUserDefaults standardUserDefaults] synchronize];
-}
-
-- (void)setPreventSelfRevokeEnable:(BOOL)preventSelfRevokeEnable {
-    _preventSelfRevokeEnable = preventSelfRevokeEnable;
-    [[NSUserDefaults standardUserDefaults] setBool:preventSelfRevokeEnable forKey:kTKPreventSelfRevokeEnableKey];
-    [[NSUserDefaults standardUserDefaults] synchronize];
-}
-
-- (void)setAutoReplyEnable:(BOOL)autoReplyEnable {
-    _autoReplyEnable = autoReplyEnable;
-    [[NSUserDefaults standardUserDefaults] setBool:autoReplyEnable forKey:kTKAutoReplyEnableKey];
-    [[NSUserDefaults standardUserDefaults] synchronize];
-}
-
-- (void)setAutoAuthEnable:(BOOL)autoAuthEnable {
-    _autoAuthEnable = autoAuthEnable;
-    [[NSUserDefaults standardUserDefaults] setBool:autoAuthEnable forKey:kTKAutoAuthEnableKey];
-    [[NSUserDefaults standardUserDefaults] synchronize];
-}
-
-- (void)setLaunchFromNew:(BOOL)launchFromNew
-{
-    _launchFromNew = launchFromNew;
-    [[NSUserDefaults standardUserDefaults] setBool:_launchFromNew forKey:kTKLaunchFromNew];
-    [[NSUserDefaults standardUserDefaults] synchronize];
-}
-
-- (void)setAutoLoginEnable:(BOOL)autoLoginEnable {
-    _autoLoginEnable = autoLoginEnable;
-    [[NSUserDefaults standardUserDefaults] setBool:autoLoginEnable forKey:kTKAutoLoginEnableKey];
-    [[NSUserDefaults standardUserDefaults] synchronize];
-}
-
-- (void)setOnTop:(BOOL)onTop {
-    _onTop = onTop;
-    [[NSUserDefaults standardUserDefaults] setBool:_onTop forKey:kTKOnTopKey];
-    [[NSUserDefaults standardUserDefaults] synchronize];
-}
-
-- (void)setForbidCheckVersion:(BOOL)forbidCheckVersion {
-    _forbidCheckVersion = forbidCheckVersion;
-    [[NSUserDefaults standardUserDefaults] setBool:_forbidCheckVersion forKey:kTKForbidCheckVersionKey];
-    [[NSUserDefaults standardUserDefaults] synchronize];
-}
-
-- (void)setAlfredEnable:(BOOL)alfredEnable {
-    _alfredEnable = alfredEnable;
-    [[NSUserDefaults standardUserDefaults] setBool:_alfredEnable forKey:kTKAlfredEnableKey];
-    [[NSUserDefaults standardUserDefaults] synchronize];
-}
-
-- (void)setCheckUpdateWechatEnable:(BOOL)checkUpdateWechatEnable {
-    _checkUpdateWechatEnable = checkUpdateWechatEnable;
-    [[NSUserDefaults standardUserDefaults] setBool:_checkUpdateWechatEnable forKey:kTKCheckUpdateWechatEnableKey];
-    [[NSUserDefaults standardUserDefaults] synchronize];
-}
-
-- (void)setSystemBrowserEnable:(BOOL)systemBrowserEnable {
-    _systemBrowserEnable = systemBrowserEnable;
-    [[NSUserDefaults standardUserDefaults] setBool:_systemBrowserEnable forKey:kTKSystemBrowserEnableKey];
-    [[NSUserDefaults standardUserDefaults] synchronize];
-}
-
-- (void)setPreventAsyncRevokeToPhone:(BOOL)preventAsyncRevokeToPhone {
-    _preventAsyncRevokeToPhone = preventAsyncRevokeToPhone;
-    [[NSUserDefaults standardUserDefaults] setBool:_preventAsyncRevokeToPhone forKey:kTKPreventAsyncRevokeKey];
-    [[NSUserDefaults standardUserDefaults] synchronize];
-}
-
-- (void)setPreventAsyncRevokeSignal:(BOOL)preventAsyncRevokeSignal {
-    _preventAsyncRevokeSignal = preventAsyncRevokeSignal;
-    [[NSUserDefaults standardUserDefaults] setBool:_preventAsyncRevokeSignal forKey:KPreventAsyncRevokeSignal];
-    [[NSUserDefaults standardUserDefaults] synchronize];
-}
-
-- (void)setPreventAsyncRevokeChatRoom:(BOOL)preventAsyncRevokeChatRoom {
-    _preventAsyncRevokeChatRoom = preventAsyncRevokeChatRoom;
-    [[NSUserDefaults standardUserDefaults] setBool:_preventAsyncRevokeChatRoom forKey:KPreventAsyncRevokeChatRoom];
-    [[NSUserDefaults standardUserDefaults] synchronize];
-}
-
-- (void)setQuitMonitorEnable:(BOOL)quitMonitorEnable
-{
-    _quitMonitorEnable = quitMonitorEnable;
-    [[NSUserDefaults standardUserDefaults] setBool:_quitMonitorEnable forKey:KQuitMonitorChatRoom];
-       [[NSUserDefaults standardUserDefaults] synchronize];
 }
 
 #pragma mark - 自动回复
@@ -231,8 +80,8 @@ static NSString * const kFirstLoadMode = @"kThemeLoadMode.";
         return;
     }
     NSString *temp = NSTemporaryDirectory();
-     NSString *filePath = [temp stringByAppendingPathComponent:@"AIAutoReply.data"];
-     [NSKeyedArchiver archiveRootObject:model toFile:filePath];
+    NSString *filePath = [temp stringByAppendingPathComponent:@"AIAutoReply.data"];
+    [NSKeyedArchiver archiveRootObject:model toFile:filePath];
 }
 
 - (void)saveAutoReplyModels {
@@ -470,5 +319,5 @@ static NSString * const kFirstLoadMode = @"kThemeLoadMode.";
     }
     return english;
 }
-@end
 
+@end

--- a/WeChatExtension/WeChatExtension/Sources/Utils/GVUserDefaults.h
+++ b/WeChatExtension/WeChatExtension/Sources/Utils/GVUserDefaults.h
@@ -1,0 +1,15 @@
+//
+//  GVUserDefaults.h
+//  GVUserDefaults
+//
+//  Created by Kevin Renskers on 18-12-12.
+//  Copyright (c) 2012 Gangverk. All rights reserved.
+//
+
+#import <Foundation/Foundation.h>
+
+@interface GVUserDefaults : NSObject
+
++ (instancetype)standardUserDefaults;
+
+@end

--- a/WeChatExtension/WeChatExtension/Sources/Utils/GVUserDefaults.m
+++ b/WeChatExtension/WeChatExtension/Sources/Utils/GVUserDefaults.m
@@ -1,0 +1,279 @@
+//
+//  GVUserDefaults.m
+//  GVUserDefaults
+//
+//  Created by Kevin Renskers on 18-12-12.
+//  Copyright (c) 2012 Gangverk. All rights reserved.
+//
+
+#import "GVUserDefaults.h"
+#import <objc/runtime.h>
+
+@interface GVUserDefaults ()
+@property (strong, nonatomic) NSMutableDictionary *mapping;
+@property (strong, nonatomic) NSUserDefaults *userDefaults;
+@end
+
+@implementation GVUserDefaults
+
+enum TypeEncodings {
+    Char                = 'c',
+    Bool                = 'B',
+    Short               = 's',
+    Int                 = 'i',
+    Long                = 'l',
+    LongLong            = 'q',
+    UnsignedChar        = 'C',
+    UnsignedShort       = 'S',
+    UnsignedInt         = 'I',
+    UnsignedLong        = 'L',
+    UnsignedLongLong    = 'Q',
+    Float               = 'f',
+    Double              = 'd',
+    Object              = '@'
+};
+
+- (NSUserDefaults *)userDefaults {
+    if (!_userDefaults) {
+        NSString *suiteName = nil;
+        if ([NSUserDefaults instancesRespondToSelector:@selector(initWithSuiteName:)]) {
+            suiteName = [self _suiteName];
+        }
+
+        if (suiteName && suiteName.length) {
+            _userDefaults = [[NSUserDefaults alloc] initWithSuiteName:suiteName];
+        } else {
+            _userDefaults = [NSUserDefaults standardUserDefaults];
+        }
+    }
+
+    return _userDefaults;
+}
+
+- (NSString *)defaultsKeyForPropertyNamed:(char const *)propertyName {
+    NSString *key = [NSString stringWithFormat:@"%s", propertyName];
+    return [self _transformKey:key];
+}
+
+- (NSString *)defaultsKeyForSelector:(SEL)selector {
+    return [self.mapping objectForKey:NSStringFromSelector(selector)];
+}
+
+static long long longLongGetter(GVUserDefaults *self, SEL _cmd) {
+    NSString *key = [self defaultsKeyForSelector:_cmd];
+    return [[self.userDefaults objectForKey:key] longLongValue];
+}
+
+static void longLongSetter(GVUserDefaults *self, SEL _cmd, long long value) {
+    NSString *key = [self defaultsKeyForSelector:_cmd];
+    NSNumber *object = [NSNumber numberWithLongLong:value];
+    [self.userDefaults setObject:object forKey:key];
+}
+
+static bool boolGetter(GVUserDefaults *self, SEL _cmd) {
+    NSString *key = [self defaultsKeyForSelector:_cmd];
+    return [self.userDefaults boolForKey:key];
+}
+
+static void boolSetter(GVUserDefaults *self, SEL _cmd, bool value) {
+    NSString *key = [self defaultsKeyForSelector:_cmd];
+    [self.userDefaults setBool:value forKey:key];
+}
+
+static int integerGetter(GVUserDefaults *self, SEL _cmd) {
+    NSString *key = [self defaultsKeyForSelector:_cmd];
+    return (int)[self.userDefaults integerForKey:key];
+}
+
+static void integerSetter(GVUserDefaults *self, SEL _cmd, int value) {
+    NSString *key = [self defaultsKeyForSelector:_cmd];
+    [self.userDefaults setInteger:value forKey:key];
+}
+
+static float floatGetter(GVUserDefaults *self, SEL _cmd) {
+    NSString *key = [self defaultsKeyForSelector:_cmd];
+    return [self.userDefaults floatForKey:key];
+}
+
+static void floatSetter(GVUserDefaults *self, SEL _cmd, float value) {
+    NSString *key = [self defaultsKeyForSelector:_cmd];
+    [self.userDefaults setFloat:value forKey:key];
+}
+
+static double doubleGetter(GVUserDefaults *self, SEL _cmd) {
+    NSString *key = [self defaultsKeyForSelector:_cmd];
+    return [self.userDefaults doubleForKey:key];
+}
+
+static void doubleSetter(GVUserDefaults *self, SEL _cmd, double value) {
+    NSString *key = [self defaultsKeyForSelector:_cmd];
+    [self.userDefaults setDouble:value forKey:key];
+}
+
+static id objectGetter(GVUserDefaults *self, SEL _cmd) {
+    NSString *key = [self defaultsKeyForSelector:_cmd];
+    return [self.userDefaults objectForKey:key];
+}
+
+static void objectSetter(GVUserDefaults *self, SEL _cmd, id object) {
+    NSString *key = [self defaultsKeyForSelector:_cmd];
+    if (object) {
+        [self.userDefaults setObject:object forKey:key];
+    } else {
+        [self.userDefaults removeObjectForKey:key];
+    }
+}
+
+#pragma mark - Begin
+
++ (instancetype)standardUserDefaults {
+    static dispatch_once_t pred;
+    static GVUserDefaults *sharedInstance = nil;
+    dispatch_once(&pred, ^{ sharedInstance = [[self alloc] init]; });
+    return sharedInstance;
+}
+
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wundeclared-selector"
+#pragma GCC diagnostic ignored "-Warc-performSelector-leaks"
+
+- (instancetype)init {
+    self = [super init];
+    if (self) {
+        SEL setupDefaultSEL = NSSelectorFromString([NSString stringWithFormat:@"%@pDefaults", @"setu"]);
+        if ([self respondsToSelector:setupDefaultSEL]) {
+            NSDictionary *defaults = [self performSelector:setupDefaultSEL];
+            NSMutableDictionary *mutableDefaults = [NSMutableDictionary dictionaryWithCapacity:[defaults count]];
+            for (NSString *key in defaults) {
+                id value = [defaults objectForKey:key];
+                NSString *transformedKey = [self _transformKey:key];
+                [mutableDefaults setObject:value forKey:transformedKey];
+            }
+            [self.userDefaults registerDefaults:mutableDefaults];
+        }
+
+        [self generateAccessorMethods];
+    }
+
+    return self;
+}
+
+- (NSString *)_transformKey:(NSString *)key {
+    if ([self respondsToSelector:@selector(transformKey:)]) {
+        return [self performSelector:@selector(transformKey:) withObject:key];
+    }
+
+    return key;
+}
+
+- (NSString *)_suiteName {
+    // Backwards compatibility (v 1.0.0)
+    if ([self respondsToSelector:@selector(suitName)]) {
+        return [self performSelector:@selector(suitName)];
+    }
+
+    if ([self respondsToSelector:@selector(suiteName)]) {
+        return [self performSelector:@selector(suiteName)];
+    }
+
+    return nil;
+}
+
+#pragma GCC diagnostic pop
+
+- (void)generateAccessorMethods {
+    unsigned int count = 0;
+    objc_property_t *properties = class_copyPropertyList([self class], &count);
+
+    self.mapping = [NSMutableDictionary dictionary];
+
+    for (int i = 0; i < count; ++i) {
+        objc_property_t property = properties[i];
+        const char *name = property_getName(property);
+        const char *attributes = property_getAttributes(property);
+
+        char *getter = strstr(attributes, ",G");
+        if (getter) {
+            getter = strdup(getter + 2);
+            getter = strsep(&getter, ",");
+        } else {
+            getter = strdup(name);
+        }
+        SEL getterSel = sel_registerName(getter);
+        free(getter);
+
+        char *setter = strstr(attributes, ",S");
+        if (setter) {
+            setter = strdup(setter + 2);
+            setter = strsep(&setter, ",");
+        } else {
+            asprintf(&setter, "set%c%s:", toupper(name[0]), name + 1);
+        }
+        SEL setterSel = sel_registerName(setter);
+        free(setter);
+
+        NSString *key = [self defaultsKeyForPropertyNamed:name];
+        [self.mapping setValue:key forKey:NSStringFromSelector(getterSel)];
+        [self.mapping setValue:key forKey:NSStringFromSelector(setterSel)];
+
+        IMP getterImp = NULL;
+        IMP setterImp = NULL;
+        char type = attributes[1];
+        switch (type) {
+            case Short:
+            case Long:
+            case LongLong:
+            case UnsignedChar:
+            case UnsignedShort:
+            case UnsignedInt:
+            case UnsignedLong:
+            case UnsignedLongLong:
+                getterImp = (IMP)longLongGetter;
+                setterImp = (IMP)longLongSetter;
+                break;
+
+            case Bool:
+            case Char:
+                getterImp = (IMP)boolGetter;
+                setterImp = (IMP)boolSetter;
+                break;
+
+            case Int:
+                getterImp = (IMP)integerGetter;
+                setterImp = (IMP)integerSetter;
+                break;
+
+            case Float:
+                getterImp = (IMP)floatGetter;
+                setterImp = (IMP)floatSetter;
+                break;
+
+            case Double:
+                getterImp = (IMP)doubleGetter;
+                setterImp = (IMP)doubleSetter;
+                break;
+
+            case Object:
+                getterImp = (IMP)objectGetter;
+                setterImp = (IMP)objectSetter;
+                break;
+
+            default:
+                free(properties);
+                [NSException raise:NSInternalInconsistencyException format:@"Unsupported type of property \"%s\" in class %@", name, self];
+                break;
+        }
+
+        char types[5];
+
+        snprintf(types, 4, "%c@:", type);
+        class_addMethod([self class], getterSel, getterImp, types);
+        
+        snprintf(types, 5, "v@:%c", type);
+        class_addMethod([self class], setterSel, setterImp, types);
+    }
+
+    free(properties);
+}
+
+@end


### PR DESCRIPTION
TKWeChatPluginConfig 中有不少冗余的 setter 代码，而且 key 的值定义没有遵循统一的格式。
用 [GVUserDefaults](https://github.com/gangverk/GVUserDefaults) 可以避免这些问题，减少重复代码。