### PR TITLE
docs: 更新 Oh My WeChat 的安装地址

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,7 +108,7 @@ sudo rm -r -f WeChatExtension-ForMac && git clone --depth=1 https://github.com/M
 打开`应用程序-实用工具-Terminal(终端)`，执行下面的命令安装 [Oh My WeChat](https://github.com/lmk123/oh-my-wechat)：
 
 ```sh
-curl -o- -L https://raw.githubusercontent.com/lmk123/oh-my-wechat/master/install.sh | bash -s
+curl -o- -L https://omw.limingkai.cn/install.sh | bash -s
 ```
 
 安装完成后会自动安装微信插件，可以访问 [Oh My WeChat 的项目主页](https://github.com/lmk123/oh-my-wechat#oh-my-wechat)查看更多用法。


### PR DESCRIPTION
由于 raw.githubusercontent.com 被屏蔽，所以原本的在线安装不能用了，这个 pr 更新了最新的安装地址